### PR TITLE
Add node-fetch dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "dependencies": {
+    "node-fetch": "^2.2.0"
+  },
   "keywords": [
     "delion",
     "remote-pow",


### PR DESCRIPTION
`node-fetch` is required but not included in the dependencies.